### PR TITLE
Feature/create event

### DIFF
--- a/app/controllers/api/v1/device_events_controller.rb
+++ b/app/controllers/api/v1/device_events_controller.rb
@@ -1,3 +1,4 @@
 class Api::V1::DeviceEventsController < ApplicationController
-
+    def create
+    end
 end

--- a/app/controllers/api/v1/device_events_controller.rb
+++ b/app/controllers/api/v1/device_events_controller.rb
@@ -1,4 +1,14 @@
 class Api::V1::DeviceEventsController < ApplicationController
-    def create
+    def create 
+        device_event = DeviceEvent.new(device_event_params)
+        if device_event.save
+            render json: device_event, status: :ok
+        else 
+            render json: device_event.errors, status: :unprocessable_entity
+        end 
+    end
+
+    def device_event_params
+        params.require(:device_event).permit(:category, :recorded_at)
     end
 end

--- a/app/controllers/api/v1/device_events_controller.rb
+++ b/app/controllers/api/v1/device_events_controller.rb
@@ -1,0 +1,3 @@
+class Api::V1::DeviceEventsController < ApplicationController
+
+end

--- a/app/models/device_event.rb
+++ b/app/models/device_event.rb
@@ -1,2 +1,3 @@
 class DeviceEvent < ApplicationRecord
+
 end

--- a/app/models/device_event.rb
+++ b/app/models/device_event.rb
@@ -1,3 +1,21 @@
 class DeviceEvent < ApplicationRecord
+    before_create :set_received_at
 
+    validates :category, :recorded_at, presence: true
+    attr_readonly :received_at
+    validate :attributes_not_set_at_creation
+
+    def set_received_at
+        self.received_at = Time.current
+    end
+
+    private 
+
+    def attributes_not_set_at_creation
+        if new_record?
+            if notification_sent.present? || is_deleted.present? || received_at.present?
+                errors.add(:base, "notification_sent, is_deleted or received_at cannot be set at creation")
+            end
+        end
+    end
 end

--- a/app/models/device_event.rb
+++ b/app/models/device_event.rb
@@ -4,6 +4,7 @@ class DeviceEvent < ApplicationRecord
     validates :category, :recorded_at, presence: true
     attr_readonly :received_at
     validate :attributes_not_set_at_creation
+    after_initialize :init
 
     def set_received_at
         self.received_at = Time.current
@@ -17,5 +18,9 @@ class DeviceEvent < ApplicationRecord
                 errors.add(:base, "notification_sent, is_deleted or received_at cannot be set at creation")
             end
         end
+    end
+    def init
+        self.is_deleted = false if self.is_deleted.nil?
+        self.notification_sent = false if self.notification_sent.nil?
     end
 end

--- a/app/models/device_event.rb
+++ b/app/models/device_event.rb
@@ -1,0 +1,2 @@
+class DeviceEvent < ApplicationRecord
+end

--- a/config/initializers/generators.rb
+++ b/config/initializers/generators.rb
@@ -1,0 +1,3 @@
+Rails.application.config.generators do |gs|
+    gs.orm :active_record, primary_key_type: :uuid
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,8 @@
 Rails.application.routes.draw do
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-
-  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
-  # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check
-
-  # Defines the root path route ("/")
-  # root "posts#index"
+  namespace "api" do
+    namespace "v1" do
+      resources :device_events
+    end
+  end
 end

--- a/db/migrate/20231211221543_create_device_events.rb
+++ b/db/migrate/20231211221543_create_device_events.rb
@@ -1,0 +1,16 @@
+class CreateDeviceEvents < ActiveRecord::Migration[7.1]
+  def change
+    create_table :device_events do |t|
+      t.uuid :uuid
+      t.datetime :recorded_at
+      t.datetime :received_at
+      t.string :device_uuid
+      t.jsonb :metadata
+      t.boolean :notification_sent
+      t.boolean :is_deleted
+      t.integer :category
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20231211221543_create_device_events.rb
+++ b/db/migrate/20231211221543_create_device_events.rb
@@ -1,7 +1,6 @@
 class CreateDeviceEvents < ActiveRecord::Migration[7.1]
   def change
-    create_table :device_events do |t|
-      t.uuid :uuid
+    create_table :device_events, id: :uuid do |t|
       t.datetime :recorded_at
       t.datetime :received_at
       t.string :device_uuid

--- a/db/migrate/20231212163338_postgres_uuid.rb
+++ b/db/migrate/20231212163338_postgres_uuid.rb
@@ -1,0 +1,5 @@
+class PostgresUuid < ActiveRecord::Migration[7.1]
+  def change
+    enable_extension 'pgcrypto'
+  end
+end

--- a/db/migrate/20231213113140_change_id_to_uuid.rb
+++ b/db/migrate/20231213113140_change_id_to_uuid.rb
@@ -1,0 +1,6 @@
+class ChangeIdToUuid < ActiveRecord::Migration[7.1]
+  def change
+    rename_column :device_events, :id, :uuid
+    change_column :device_events, :uuid, :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,18 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_12_11_221543) do
+ActiveRecord::Schema[7.1].define(version: 2023_12_12_163338) do
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
-  create_table "device_events", force: :cascade do |t|
-    t.uuid "uuid"
+  create_table "device_events", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "recorded_at"
     t.datetime "received_at"
     t.string "device_uuid"
     t.jsonb "metadata"
-    t.boolean "notification_sent", default: false
-    t.boolean "is_deleted", default: false
+    t.boolean "notification_sent"
+    t.boolean "is_deleted"
     t.integer "category"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -20,8 +20,8 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_11_221543) do
     t.datetime "received_at"
     t.string "device_uuid"
     t.jsonb "metadata"
-    t.boolean "notification_sent"
-    t.boolean "is_deleted"
+    t.boolean "notification_sent", default: false
+    t.boolean "is_deleted", default: false
     t.integer "category"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_12_12_163338) do
+ActiveRecord::Schema[7.1].define(version: 2023_12_13_113140) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
-  create_table "device_events", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "device_events", primary_key: "uuid", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "recorded_at"
     t.datetime "received_at"
     t.string "device_uuid"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,30 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.1].define(version: 2023_12_11_221543) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "device_events", force: :cascade do |t|
+    t.uuid "uuid"
+    t.datetime "recorded_at"
+    t.datetime "received_at"
+    t.string "device_uuid"
+    t.jsonb "metadata"
+    t.boolean "notification_sent"
+    t.boolean "is_deleted"
+    t.integer "category"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+end

--- a/test/controllers/device_events_controller_test.rb
+++ b/test/controllers/device_events_controller_test.rb
@@ -1,7 +1,29 @@
 require "test_helper"
 
 class DeviceEventsControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
+
+  test "create valid device event with valid parameters" do
+    post '/api/v1/device_events', params: { device_event: { category: 1, recorded_at: Date.current } }
+    assert_response :ok
+    device_event = JSON.parse(response.body)
+    assert_not_nil device_event['uuid']
+    assert_equal 1, device_event['category']
+  end
+
+  test "create invalid device event with category parameter missing" do
+    post '/api/v1/device_events', params: { device_event: { recorded_at: Date.current } }
+    assert_response :unprocessable_entity
+    errors = JSON.parse(response.body)
+    expected_error_message = { "category" => ["can't be blank"] }
+    assert_equal expected_error_message, errors
+  end
+
+  test "create invalid device event with recorded_at parameter missing" do
+    post '/api/v1/device_events', params: { device_event: { category: 1 } }
+    assert_response :unprocessable_entity
+    errors = JSON.parse(response.body)
+    expected_error_message = { "recorded_at" => ["can't be blank"] }
+    assert_equal expected_error_message, errors
+  end
+
 end

--- a/test/controllers/device_events_controller_test.rb
+++ b/test/controllers/device_events_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class DeviceEventsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/device_events.yml
+++ b/test/fixtures/device_events.yml
@@ -1,0 +1,21 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  uuid: 
+  recorded_at: 2023-12-11 22:15:43
+  received_at: 2023-12-11 22:15:43
+  device_uuid: MyString
+  metadata: 
+  notification_sent: false
+  is_deleted: false
+  category: 1
+
+two:
+  uuid: 
+  recorded_at: 2023-12-11 22:15:43
+  received_at: 2023-12-11 22:15:43
+  device_uuid: MyString
+  metadata: 
+  notification_sent: false
+  is_deleted: false
+  category: 1

--- a/test/fixtures/device_events.yml
+++ b/test/fixtures/device_events.yml
@@ -1,7 +1,6 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  uuid: 
   recorded_at: 2023-12-11 22:15:43
   received_at: 2023-12-11 22:15:43
   device_uuid: MyString
@@ -11,7 +10,6 @@ one:
   category: 1
 
 two:
-  uuid: 
   recorded_at: 2023-12-11 22:15:43
   received_at: 2023-12-11 22:15:43
   device_uuid: MyString

--- a/test/models/device_event_test.rb
+++ b/test/models/device_event_test.rb
@@ -10,7 +10,6 @@ class DeviceEventTest < ActiveSupport::TestCase
 
   test 'invalid device event missing recorded_at' do
     device_event = DeviceEvent.new(device_uuid: "342354764723", category: 2)
-    puts device_event.received_at
     assert_not device_event.valid?
   end
 
@@ -20,17 +19,17 @@ class DeviceEventTest < ActiveSupport::TestCase
     assert_not device_event.valid?
   end
 
-  test 'invalid device event with received_at' do
+  test 'invalid device event with received_at set at creation' do
     device_event = DeviceEvent.new(recorded_at: Date.today, received_at: Date.today, device_uuid: "342354764723", category: 2)
     assert_not device_event.valid?
   end
 
-  test 'invalid device event with notification_sent' do
+  test 'invalid device event with notification_sent set at creation' do
     device_event = DeviceEvent.new(recorded_at: Date.today, received_at: Date.today, device_uuid: "342354764723", notification_sent: false, category: 2)
     assert_not device_event.valid?
   end
 
-  test 'invalid device event with is_deleted' do
+  test 'invalid device event with is_deleted set at creation' do
     device_event = DeviceEvent.new(recorded_at: Date.today, received_at: Date.today, device_uuid: "342354764723", is_deleted: false, category: 2)
     assert_not device_event.valid?
   end

--- a/test/models/device_event_test.rb
+++ b/test/models/device_event_test.rb
@@ -2,34 +2,34 @@ require "test_helper"
 
 class DeviceEventTest < ActiveSupport::TestCase
 
-  test 'valid device event' do
+  test 'create valid device event' do
     device_event = DeviceEvent.new(recorded_at: Date.today, device_uuid: "342354764723", category: 2)
     puts device_event.received_at
     assert device_event.valid?
   end
 
-  test 'invalid device event missing recorded_at' do
+  test 'create invalid device event missing recorded_at' do
     device_event = DeviceEvent.new(device_uuid: "342354764723", category: 2)
     assert_not device_event.valid?
   end
 
-  test 'invalid device event missing category' do
+  test 'create invalid device event missing category' do
     device_event = DeviceEvent.new(recorded_at: Date.today, device_uuid: "342354764723")
     puts device_event.received_at
     assert_not device_event.valid?
   end
 
-  test 'invalid device event with received_at set at creation' do
+  test 'create invalid device event with received_at set at creation' do
     device_event = DeviceEvent.new(recorded_at: Date.today, received_at: Date.today, device_uuid: "342354764723", category: 2)
     assert_not device_event.valid?
   end
 
-  test 'invalid device event with notification_sent set at creation' do
+  test 'create invalid device event with notification_sent set at creation' do
     device_event = DeviceEvent.new(recorded_at: Date.today, received_at: Date.today, device_uuid: "342354764723", notification_sent: false, category: 2)
     assert_not device_event.valid?
   end
 
-  test 'invalid device event with is_deleted set at creation' do
+  test 'create invalid device event with is_deleted set at creation' do
     device_event = DeviceEvent.new(recorded_at: Date.today, received_at: Date.today, device_uuid: "342354764723", is_deleted: false, category: 2)
     assert_not device_event.valid?
   end

--- a/test/models/device_event_test.rb
+++ b/test/models/device_event_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class DeviceEventTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/device_event_test.rb
+++ b/test/models/device_event_test.rb
@@ -1,7 +1,37 @@
 require "test_helper"
 
 class DeviceEventTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+
+  test 'valid device event' do
+    device_event = DeviceEvent.new(recorded_at: Date.today, device_uuid: "342354764723", category: 2)
+    puts device_event.received_at
+    assert device_event.valid?
+  end
+
+  test 'invalid device event missing recorded_at' do
+    device_event = DeviceEvent.new(device_uuid: "342354764723", category: 2)
+    puts device_event.received_at
+    assert_not device_event.valid?
+  end
+
+  test 'invalid device event missing category' do
+    device_event = DeviceEvent.new(recorded_at: Date.today, device_uuid: "342354764723")
+    puts device_event.received_at
+    assert_not device_event.valid?
+  end
+
+  test 'invalid device event with received_at' do
+    device_event = DeviceEvent.new(recorded_at: Date.today, received_at: Date.today, device_uuid: "342354764723", category: 2)
+    assert_not device_event.valid?
+  end
+
+  test 'invalid device event with notification_sent' do
+    device_event = DeviceEvent.new(recorded_at: Date.today, received_at: Date.today, device_uuid: "342354764723", notification_sent: false, category: 2)
+    assert_not device_event.valid?
+  end
+
+  test 'invalid device event with is_deleted' do
+    device_event = DeviceEvent.new(recorded_at: Date.today, received_at: Date.today, device_uuid: "342354764723", is_deleted: false, category: 2)
+    assert_not device_event.valid?
+  end
 end


### PR DESCRIPTION
- Created migration to generate UUIDs automatically.
- Changed the ID column to UUID to comply with spec
- Added a new **POST** endpoint for creating device events and necessary tests for it

#### Example:
```bash
curl --request POST \
  --url http://localhost:3000/api/v1/device_events \
  --header 'Content-Type: application/json' \
  --data '{
    "device_uuid": "43267436298", 
    "recorded_at": "2023-12-11 22:15:43", 
    "category": 1
  }'
