### PR TITLE
Feature/update event

### DIFF
--- a/app/controllers/api/v1/device_events_controller.rb
+++ b/app/controllers/api/v1/device_events_controller.rb
@@ -8,6 +8,20 @@ class Api::V1::DeviceEventsController < ApplicationController
         end 
     end
 
+    def update_notification
+        @device_event = DeviceEvent.find(params[:id])
+    
+        if @device_event.notification_sent?
+            render json: { error: "Notification has already been sent for this event" }, status: :unprocessable_entity
+        else
+            if @device_event.update(notification_sent: true)
+                render json: @device_event, status: :ok
+            else
+                render json: { error: "Failed to update notification status" }, status: :bad_request
+            end
+        end
+    end
+
     def device_event_params
         params.require(:device_event).permit(:category, :recorded_at)
     end

--- a/app/controllers/api/v1/device_events_controller.rb
+++ b/app/controllers/api/v1/device_events_controller.rb
@@ -8,10 +8,6 @@ class Api::V1::DeviceEventsController < ApplicationController
         end 
     end
 
-    def update_notification
-
-    end
-
     def device_event_params
         params.require(:device_event).permit(:category, :recorded_at)
     end

--- a/app/controllers/api/v1/device_events_controller.rb
+++ b/app/controllers/api/v1/device_events_controller.rb
@@ -8,6 +8,10 @@ class Api::V1::DeviceEventsController < ApplicationController
         end 
     end
 
+    def update_notification
+
+    end
+
     def device_event_params
         params.require(:device_event).permit(:category, :recorded_at)
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,13 @@
 Rails.application.routes.draw do
   get "up" => "rails/health#show", as: :rails_health_check
+  
   namespace "api" do
     namespace "v1" do
-      resources :device_events
+      resources :device_events do
+        member do
+          patch 'update-notification', to: 'device_events#update_notification', as: :update_notification
+        end
+      end
     end
   end
 end

--- a/test/controllers/device_events_controller_test.rb
+++ b/test/controllers/device_events_controller_test.rb
@@ -5,11 +5,11 @@ class DeviceEventsControllerTest < ActionDispatch::IntegrationTest
   class DeviceEventsCreateTest < DeviceEventsControllerTest
 
     test "create valid device event with valid parameters" do
-      post '/api/v1/device_events', params: { device_event: { category: 1, recorded_at: Date.current } }
+      post '/api/v1/device_events', params: { device_event: { category: 2, recorded_at: Date.current } }
       assert_response :ok
       device_event = JSON.parse(response.body)
       assert_not_nil device_event['uuid']
-      assert_equal 1, device_event['category']
+      assert_equal 2, device_event['category']
     end
   
     test "create invalid device event with category parameter missing" do

--- a/test/controllers/device_events_controller_test.rb
+++ b/test/controllers/device_events_controller_test.rb
@@ -15,17 +15,17 @@ class DeviceEventsControllerTest < ActionDispatch::IntegrationTest
     test "create invalid device event with category parameter missing" do
       post '/api/v1/device_events', params: { device_event: { recorded_at: Date.current } }
       assert_response :unprocessable_entity
-      errors = JSON.parse(response.body)
+      error_message = JSON.parse(response.body)
       expected_error_message = { "category" => ["can't be blank"] }
-      assert_equal expected_error_message, errors
+      assert_equal expected_error_message, error_message
     end
   
     test "create invalid device event with recorded_at parameter missing" do
       post '/api/v1/device_events', params: { device_event: { category: 1 } }
       assert_response :unprocessable_entity
-      errors = JSON.parse(response.body)
+      error_message = JSON.parse(response.body)
       expected_error_message = { "recorded_at" => ["can't be blank"] }
-      assert_equal expected_error_message, errors
+      assert_equal expected_error_message, error_message
     end
 
   end
@@ -33,26 +33,28 @@ class DeviceEventsControllerTest < ActionDispatch::IntegrationTest
   class DeviceEventsUpdateNotificationTest < DeviceEventsControllerTest
 
     test "update notification_sent flag to true when it set to false" do
-      device_event = DeviceEvent.create(notification_sent: false)
-      patch '/api/v1/device_events/#{device_event.id}/update-notification'
+      device_event = DeviceEvent.create(category:1, recorded_at: Date.today)
+      patch "/api/v1/device_events/#{device_event.uuid}/update-notification"
       assert_response :ok
-      device_event = JSON.parse(response.body)
-      assert_true device_event['notification_sent']
+      updated_device_event = JSON.parse(response.body)
+      assert_equal updated_device_event['notification_sent'], true
     end
 
-
     test "return not found when the supplied event does not exist" do
-      non_existent_event_id = 47382
-      patch "/api/v1/device_events/#{non_existent_event_id}/update-notification"
+      non_existent_event_uuid = 47382
+      patch "/api/v1/device_events/#{non_existent_event_uuid}/update-notification"
       assert_response :not_found
     end
 
-    test "return unprocessable entity and error message if the flag was set to true already" do
-      device_event = DeviceEvent.create(notification_sent: true)
-      patch "/api/v1/device_events/#{device_event.id}/update-notification"
+    test "update notification_sent flag to true when it set to false 2" do
+      device_event = DeviceEvent.create(category:3, recorded_at: Date.yesterday)
+      patch "/api/v1/device_events/#{device_event.uuid}/update-notification"
+      assert_response :ok
+      patch "/api/v1/device_events/#{device_event.uuid}/update-notification"
       assert_response :unprocessable_entity
-      error_response = JSON.parse(response.body)
-      assert_equal error_response, 'notification_sent was already set to true'
+      error_message = JSON.parse(response.body)
+      expected_error_message = { "error" => "Notification has already been sent for this event" }
+      assert_equal expected_error_message, error_message
     end
 
   end

--- a/test/controllers/device_events_controller_test.rb
+++ b/test/controllers/device_events_controller_test.rb
@@ -2,28 +2,59 @@ require "test_helper"
 
 class DeviceEventsControllerTest < ActionDispatch::IntegrationTest
 
-  test "create valid device event with valid parameters" do
-    post '/api/v1/device_events', params: { device_event: { category: 1, recorded_at: Date.current } }
-    assert_response :ok
-    device_event = JSON.parse(response.body)
-    assert_not_nil device_event['uuid']
-    assert_equal 1, device_event['category']
+  class DeviceEventsCreateTest < DeviceEventsControllerTest
+
+    test "create valid device event with valid parameters" do
+      post '/api/v1/device_events', params: { device_event: { category: 1, recorded_at: Date.current } }
+      assert_response :ok
+      device_event = JSON.parse(response.body)
+      assert_not_nil device_event['uuid']
+      assert_equal 1, device_event['category']
+    end
+  
+    test "create invalid device event with category parameter missing" do
+      post '/api/v1/device_events', params: { device_event: { recorded_at: Date.current } }
+      assert_response :unprocessable_entity
+      errors = JSON.parse(response.body)
+      expected_error_message = { "category" => ["can't be blank"] }
+      assert_equal expected_error_message, errors
+    end
+  
+    test "create invalid device event with recorded_at parameter missing" do
+      post '/api/v1/device_events', params: { device_event: { category: 1 } }
+      assert_response :unprocessable_entity
+      errors = JSON.parse(response.body)
+      expected_error_message = { "recorded_at" => ["can't be blank"] }
+      assert_equal expected_error_message, errors
+    end
+
   end
 
-  test "create invalid device event with category parameter missing" do
-    post '/api/v1/device_events', params: { device_event: { recorded_at: Date.current } }
-    assert_response :unprocessable_entity
-    errors = JSON.parse(response.body)
-    expected_error_message = { "category" => ["can't be blank"] }
-    assert_equal expected_error_message, errors
-  end
+  class DeviceEventsUpdateNotificationTest < DeviceEventsControllerTest
 
-  test "create invalid device event with recorded_at parameter missing" do
-    post '/api/v1/device_events', params: { device_event: { category: 1 } }
-    assert_response :unprocessable_entity
-    errors = JSON.parse(response.body)
-    expected_error_message = { "recorded_at" => ["can't be blank"] }
-    assert_equal expected_error_message, errors
-  end
+    test "update notification_sent flag to true when it set to false" do
+      device_event = DeviceEvent.create(notification_sent: false)
+      patch '/api/v1/device_events/#{device_event.id}/update-notification'
+      assert_response :ok
+      device_event = JSON.parse(response.body)
+      assert_true device_event['notification_sent']
+    end
 
+
+    test "return not found when the supplied event does not exist" do
+      non_existent_event_id = 47382
+      patch "/api/v1/device_events/#{non_existent_event_id}/update-notification"
+      assert_response :not_found
+    end
+
+    test "return unprocessable entity and error message if the flag was set to true already" do
+      device_event = DeviceEvent.create(notification_sent: true)
+      patch "/api/v1/device_events/#{device_event.id}/update-notification"
+      assert_response :unprocessable_entity
+      error_response = JSON.parse(response.body)
+      assert_equal error_response, 'notification_sent was already set to true'
+    end
+
+  end
+  
 end


### PR DESCRIPTION
- Added a new PATCH endpoint which updates the `notification_sent` attribute to true, returns unprocessable request if the flag was already true. 

#### Example:
```bash
curl --request PATCH \
  --url http://localhost:3000/api/v1/device_events/f94ccca5-b241-4dde-adfb-cccf6df78c01/update-notification
  --header 'Content-Type: application/json' \