### PR TITLE
Feature/get event

### DIFF
--- a/app/controllers/api/v1/device_events_controller.rb
+++ b/app/controllers/api/v1/device_events_controller.rb
@@ -22,6 +22,15 @@ class Api::V1::DeviceEventsController < ApplicationController
         end
     end
 
+    def show
+        device_event = DeviceEvent.find_by(uuid: params[:id])
+        if device_event
+            render json: device_event, status: :ok
+        else
+            render json: { error: 'Device Event not found' }, status: :not_found
+        end
+    end
+
     def device_event_params
         params.require(:device_event).permit(:category, :recorded_at)
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
           patch 'update-notification', to: 'device_events#update_notification', as: :update_notification
         end
       end
+      get 'device_events/:id', to: 'device_events#show', as: :show_device_event
     end
   end
 end

--- a/test/controllers/device_events_controller_test.rb
+++ b/test/controllers/device_events_controller_test.rb
@@ -71,12 +71,11 @@ class DeviceEventsControllerTest < ActionDispatch::IntegrationTest
       assert_equal false, device_event['notification_sent']
     end
 
-    test "get device event" do
+    test "get non existent event" do
       non_existent_event_uuid = 47382
       get "/api/v1/device_events/#{non_existent_event_uuid}"
       assert_response :not_found
     end
-
 
   end
   

--- a/test/controllers/device_events_controller_test.rb
+++ b/test/controllers/device_events_controller_test.rb
@@ -58,5 +58,26 @@ class DeviceEventsControllerTest < ActionDispatch::IntegrationTest
     end
 
   end
+
+  class DeviceEventsGetTest < DeviceEventsControllerTest
+
+    test "get device event" do
+      device_event = DeviceEvent.create(category:4, recorded_at: Date.yesterday)
+      get "/api/v1/device_events/#{device_event.uuid}"
+      assert_response :ok
+      assert_equal 4, device_event['category']
+      assert_equal device_event.uuid, device_event['uuid']
+      assert_equal false, device_event['is_deleted']
+      assert_equal false, device_event['notification_sent']
+    end
+
+    test "get device event" do
+      non_existent_event_uuid = 47382
+      get "/api/v1/device_events/#{non_existent_event_uuid}"
+      assert_response :not_found
+    end
+
+
+  end
   
 end


### PR DESCRIPTION
- Created a get device endpoint which retrieves the event if the uuid exists and a not found error if it does not. 

#### Example:
```bash
curl --request GET \
  --url http://localhost:3000/api/v1/device_events/5c85ad73-0266-4df5-a9d0-690a96661f34 
  --header 'Content-Type: application/json' 
