### PR TITLE
Feature/delete event

### DIFF
--- a/app/controllers/api/v1/device_events_controller.rb
+++ b/app/controllers/api/v1/device_events_controller.rb
@@ -37,6 +37,20 @@ class Api::V1::DeviceEventsController < ApplicationController
         end
     end
 
+    def destroy
+        @device_event = DeviceEvent.find(params[:id])
+    
+        if @device_event.is_deleted?
+            render json: { error: "This event has already been deleted" }, status: :unprocessable_entity
+        else
+            if @device_event.update(is_deleted: true)
+                render json: @device_event, status: :ok
+            else
+                render json: { error: "Failed to delete event" }, status: :bad_request
+            end
+        end
+    end
+
     def device_event_params
         params.require(:device_event).permit(:category, :recorded_at)
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,9 +8,6 @@ Rails.application.routes.draw do
           patch 'update-notification', to: 'device_events#update_notification', as: :update_notification
         end
       end
-
-      get 'device_events/:id', to: 'device_events#show', as: :show_device_event
-      get 'device_events', to: 'device_events#index', as: :all_device_events
     end
   end
 end

--- a/test/controllers/device_events_controller_test.rb
+++ b/test/controllers/device_events_controller_test.rb
@@ -32,7 +32,7 @@ class DeviceEventsControllerTest < ActionDispatch::IntegrationTest
 
   class DeviceEventsUpdateNotificationTest < DeviceEventsControllerTest
 
-    test "update notification_sent flag to true when it set to false" do
+    test "update notification_sent attribute to true when it set to false" do
       device_event = DeviceEvent.create(category:1, recorded_at: Date.today)
       patch "/api/v1/device_events/#{device_event.uuid}/update-notification"
       assert_response :ok
@@ -46,7 +46,7 @@ class DeviceEventsControllerTest < ActionDispatch::IntegrationTest
       assert_response :not_found
     end
 
-    test "update notification_sent flag to true when it set to false 2" do
+    test "error when update notification_sent attribute is already true" do
       device_event = DeviceEvent.create(category:3, recorded_at: Date.yesterday)
       patch "/api/v1/device_events/#{device_event.uuid}/update-notification"
       assert_response :ok
@@ -106,6 +106,35 @@ class DeviceEventsControllerTest < ActionDispatch::IntegrationTest
 
       all_device_events = JSON.parse(response.body)
       assert_empty all_device_events
+    end
+
+  end
+
+  class DeviceEventsDeleteTest < DeviceEventsControllerTest
+
+    test "update is_deleted attribute to true when it set to false" do
+      device_event = DeviceEvent.create(category:1, recorded_at: Date.today)
+      delete "/api/v1/device_events/#{device_event.uuid}"
+      assert_response :ok
+      updated_device_event = JSON.parse(response.body)
+      assert_equal updated_device_event['is_deleted'], true
+    end
+
+    test "return not found when the supplied event does not exist" do
+      non_existent_event_uuid = 47382
+      delete "/api/v1/device_events/#{non_existent_event_uuid}"
+      assert_response :not_found
+    end
+
+    test "error when update is_deleted attribute is already true" do
+      device_event = DeviceEvent.create(category:5, recorded_at: Date.yesterday)
+      delete "/api/v1/device_events/#{device_event.uuid}"
+      assert_response :ok
+      delete "/api/v1/device_events/#{device_event.uuid}"
+      assert_response :unprocessable_entity
+      error_message = JSON.parse(response.body)
+      expected_error_message = { "error" => "This event has already been deleted" }
+      assert_equal expected_error_message, error_message
     end
 
   end


### PR DESCRIPTION
- Added new delete endpoint which sets is_deleted true and returns error if it is already set to true. 

#### Example:
```bash
curl --request DELETE \
  --url http://localhost:3000/api/v1/device_events/989f1057-b455-4bd4-a5e2-7ab7b3de64f3 \
  --header 'Content-Type: application/json' \