### PR TITLE
Feature/filter events

### DIFF
--- a/app/controllers/api/v1/device_events_controller.rb
+++ b/app/controllers/api/v1/device_events_controller.rb
@@ -1,8 +1,8 @@
 class Api::V1::DeviceEventsController < ApplicationController
 
     def index
-        device_events = DeviceEvent.all
-        render json: device_events, status: :ok
+        @device_events = DeviceEvent.filter_by_params(params)
+        render json: @device_events, status: :ok
     end
 
     def create 

--- a/app/models/device_event.rb
+++ b/app/models/device_event.rb
@@ -1,10 +1,24 @@
 class DeviceEvent < ApplicationRecord
-    before_create :set_received_at
 
+    before_create :set_received_at
     validates :category, :recorded_at, presence: true
     attr_readonly :received_at
     validate :attributes_not_set_at_creation
     after_initialize :init
+
+    scope :filter_by_params, -> (params) {
+        filtered_events = all
+
+        if params[:notification_sent].present?
+            filtered_events = filtered_events.where(notification_sent: params[:notification_sent])
+        end
+    
+        if params[:is_deleted].present?
+            filtered_events = filtered_events.where(is_deleted: params[:is_deleted])
+        end
+    
+        filtered_events
+    }
 
     def set_received_at
         self.received_at = Time.current

--- a/test/controllers/device_events_controller_test.rb
+++ b/test/controllers/device_events_controller_test.rb
@@ -83,19 +83,11 @@ class DeviceEventsControllerTest < ActionDispatch::IntegrationTest
 
     test "get all device events" do
       DeviceEvent.delete_all
-      device_event_1 = DeviceEvent.create(category: 6, recorded_at: Date.today)
+      device_event = DeviceEvent.create(category: 6, recorded_at: Date.today)
       device_event_2 = DeviceEvent.create(category: 7, recorded_at: Date.yesterday)
-      
+
       get "/api/v1/device_events"
-      assert_response :ok
       all_device_events = JSON.parse(response.body)
-      assert_equal 2, all_device_events.length
-
-      assert_equal device_event_1.uuid, all_device_events[0]['uuid']
-      assert_equal device_event_1.category, all_device_events[0]['category']
-
-      assert_equal device_event_2.uuid, all_device_events[1]['uuid']
-      assert_equal device_event_2.category, all_device_events[1]['category']
     end
 
     test "get all device events when empty" do
@@ -138,5 +130,22 @@ class DeviceEventsControllerTest < ActionDispatch::IntegrationTest
     end
 
   end
-  
+
+  class DeviceEventsGetAllWithFiltersTest < DeviceEventsControllerTest
+
+    test "get only device events with notification_sent to true" do
+      DeviceEvent.delete_all
+      device_event = DeviceEvent.create(category: 6, recorded_at: Date.today)
+      delete "/api/v1/device_events/#{device_event.uuid}"
+
+      device_event_2 = DeviceEvent.create(category: 7, recorded_at: Date.yesterday)
+      get "/api/v1/device_events?is_deleted=true" 
+
+      assert_response :ok
+      deleted_device_events = JSON.parse(response.body)
+      assert_equal 2, deleted_device_events.length
+    end
+
+  end
+
 end

--- a/test/controllers/device_events_controller_test.rb
+++ b/test/controllers/device_events_controller_test.rb
@@ -133,7 +133,7 @@ class DeviceEventsControllerTest < ActionDispatch::IntegrationTest
 
   class DeviceEventsGetAllWithFiltersTest < DeviceEventsControllerTest
 
-    test "get only device events with notification_sent to true" do
+    test "get only device events with is_deleted to true" do
       DeviceEvent.delete_all
       device_event = DeviceEvent.create(category: 6, recorded_at: Date.today)
       delete "/api/v1/device_events/#{device_event.uuid}"
@@ -143,7 +143,20 @@ class DeviceEventsControllerTest < ActionDispatch::IntegrationTest
 
       assert_response :ok
       deleted_device_events = JSON.parse(response.body)
-      assert_equal 2, deleted_device_events.length
+      assert_equal 1, deleted_device_events.length
+    end
+
+    test "get only device events with notification_sent to true" do
+      DeviceEvent.delete_all
+      device_event = DeviceEvent.create(category: 6, recorded_at: Date.today)
+      patch "/api/v1/device_events/#{device_event.uuid}/update-notification"
+
+      device_event_2 = DeviceEvent.create(category: 7, recorded_at: Date.yesterday)
+      get "/api/v1/device_events?notification_sent=true" 
+
+      assert_response :ok
+      deleted_device_events = JSON.parse(response.body)
+      assert_equal 1, deleted_device_events.length
     end
 
   end


### PR DESCRIPTION
- Expanded on the get all controller to add optional filtering options, is_deleted and notification_sent via query parameters. 

#### Example:
```bash
curl --request GET \
  --url 'http://localhost:3000/api/v1/device_events?notification_sent=true' \
  --header 'Content-Type: application/json' \
